### PR TITLE
i63-Don't select border cells when with 0 distance

### DIFF
--- a/quick_change/FurrowEventList.py
+++ b/quick_change/FurrowEventList.py
@@ -218,6 +218,10 @@ def run_border_cell_selection(field_types, epithelium, cells):
     border_radius = field_types["border radius (cells)"].value
     border_cell_target_radius = field_types["target radius"].value
 
+    # no work needs to be done with a 0 input
+    if border_radius == 0:
+        return
+
     for cell in cells:
         if cell.photoreceptor_type == PhotoreceptorType.NOT_RECEPTOR:
             distance = border_radius


### PR DESCRIPTION
closes #63 

Don't allow any border cells to be specialized when border radius is set to 0